### PR TITLE
translating whole page logic

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -851,8 +851,12 @@ async function Initialize () {
       pluginOptions.translation.thirdPartyTranslationLanguages[index] = normalizeLanguageCode(item)
     })
 
-    // in cases where API version is 1, whole page translation is not allowed
-    if (pluginOptions.api.version === 1 && pluginOptions.translation.translateWholePage) {
+    // by default, all versions from 3 and up have whole page translation turned on
+    if (pluginOptions.api.version > 2) {
+      pluginOptions.translation.translateWholePage = true;
+    }
+    // if widget with version 3 and up has whole page translation turned off in settings, it is taken into account
+    if (pluginOptions.api.version > 2 && !pluginOptions.translation.translateWholePage) {
       pluginOptions.translation.translateWholePage = false;
     }
 

--- a/index.ts
+++ b/index.ts
@@ -851,6 +851,10 @@ async function Initialize () {
       pluginOptions.translation.thirdPartyTranslationLanguages[index] = normalizeLanguageCode(item)
     })
 
+    if (pluginOptions.api.version < 2 && pluginOptions.translation.translateWholePage) {
+      pluginOptions.translation.translateWholePage = false;
+    }
+
     seoTool = new SearchEngineOptimization(pluginOptions)
     translationCache = new TranslationCache()
 

--- a/index.ts
+++ b/index.ts
@@ -851,7 +851,8 @@ async function Initialize () {
       pluginOptions.translation.thirdPartyTranslationLanguages[index] = normalizeLanguageCode(item)
     })
 
-    if (pluginOptions.api.version < 2 && pluginOptions.translation.translateWholePage) {
+    // in cases where API version is 1, whole page translation is not allowed
+    if (pluginOptions.api.version === 1 && pluginOptions.translation.translateWholePage) {
       pluginOptions.translation.translateWholePage = false;
     }
 

--- a/index.ts
+++ b/index.ts
@@ -851,13 +851,11 @@ async function Initialize () {
       pluginOptions.translation.thirdPartyTranslationLanguages[index] = normalizeLanguageCode(item)
     })
 
-    // by default, all versions from 3 and up have whole page translation turned on
-    if (pluginOptions.api.version > 2) {
-      pluginOptions.translation.translateWholePage = true;
-    }
-    // if widget with version 3 and up has whole page translation turned off in settings, it is taken into account
-    if (pluginOptions.api.version > 2 && !pluginOptions.translation.translateWholePage) {
+    if (pluginOptions.translation.translateWholePage === null && pluginOptions.api.version <= 2) {
       pluginOptions.translation.translateWholePage = false;
+    }
+    if (pluginOptions.translation.translateWholePage === null && pluginOptions.api.version > 2) {
+      pluginOptions.translation.translateWholePage = true;
     }
 
     seoTool = new SearchEngineOptimization(pluginOptions)

--- a/src/js/enums/TranslationElementMode.ts
+++ b/src/js/enums/TranslationElementMode.ts
@@ -1,5 +1,6 @@
 export enum TranslationElementMode{
     VISIBLE_ELEMENTS,
+    ALL_ELEMENTS,
     METADATA_ELEMENTS,
     URLS
 }

--- a/src/js/enums/TranslationElementMode.ts
+++ b/src/js/enums/TranslationElementMode.ts
@@ -1,6 +1,5 @@
 export enum TranslationElementMode{
     VISIBLE_ELEMENTS,
-    ALL_ELEMENTS,
     METADATA_ELEMENTS,
     URLS
 }

--- a/src/js/interfaces/IPluginOptions.ts
+++ b/src/js/interfaces/IPluginOptions.ts
@@ -48,6 +48,11 @@ export interface IPluginOptions{
      */
     autoTranslate: boolean,
 
+    /**
+     * Translate whole page immediately, without waiting while content is in screen view
+     */
+    translateWholePage: boolean,
+
     targetLanguages:Array<string>
     /**
      * Translate only tags and their children which have [translate="yes"] attribute

--- a/src/js/lib/DOMTranslation.ts
+++ b/src/js/lib/DOMTranslation.ts
@@ -1079,7 +1079,7 @@ class DOMTranslation {
    * @param sourceLanguageSame Element some level child of translatable language
    * @param isTranslatable If element is not some level of [translate="no"]. [translate="yes"] resets this
    * @param mode
-   * @param forceVisibility
+   * @param forceTranslation
    * @param currentParent
    * @param firstLevel
    * @returns
@@ -1092,12 +1092,12 @@ class DOMTranslation {
     sourceLanguageSame:boolean,
     isTranslatable:boolean,
     mode:TranslationElementMode,
-    forceVisibility: boolean,
+    forceTranslation: boolean,
     currentParent: HTMLElement,
     firstLevel: boolean = false
   ) {
     try {
-      if (element.nodeType === Node.TEXT_NODE && element.textContent.trim().length === 0 && !this.pluginOptions.translation.translateWholePage) {
+      if (element.nodeType === Node.TEXT_NODE && element.textContent.trim().length === 0) {
         return
       }
 
@@ -1119,25 +1119,28 @@ class DOMTranslation {
         // Don't translate child elements of website translator
         return
       }
-
       if (currentSourceLangSame && currentIsTranslatable) {
         if (mode === TranslationElementMode.VISIBLE_ELEMENTS) {
           if (element.nodeType === Node.ELEMENT_NODE && DOMExtensions.elementIsVisible(element, this.registredIframes)) {
             // Select <option> will always be "invisible", so we need to translate it if select itself is visible
             if (element.nodeName === 'SELECT') {
-              forceVisibility = true
+              forceTranslation = true
             }
 
             this.addUserElementToCollection(translatableElements, element)
           }
         }
         else if (mode === TranslationElementMode.ALL_ELEMENTS) {
-          forceVisibility = true;
+          // this property forces element to be translated
+          // useful in this case, when all elements, whether they are in frame or no, should be translated
+          // as well as in line 1126-1129, where select and option tag texts should be forced to translate
+          forceTranslation = true;
           this.addUserElementToCollection(translatableElements, element)
         }
         else if (mode === TranslationElementMode.METADATA_ELEMENTS) {
           const hasSeoAttributes = this.getTranslatableAttributes(element)
             .some(item => item.type === TranslatableItemType.ATTRIBUTE_SEO)
+
           if (hasSeoAttributes) {
             this.addUserElementToCollection(translatableElements, element)
           }
@@ -1179,7 +1182,7 @@ class DOMTranslation {
           currentSourceLangSame,
           currentIsTranslatable,
           mode,
-          forceVisibility,
+          forceTranslation,
           currentParent
         )
       }
@@ -1192,7 +1195,7 @@ class DOMTranslation {
               const visibleChildAllowed = mode === TranslationElementMode.VISIBLE_ELEMENTS && DOMExtensions.elementIsVisible(element.parentElement, this.registredIframes)
               const metadataChildAllowed = mode === TranslationElementMode.METADATA_ELEMENTS && TranslationElementCandidates.get(element.parentElement.nodeName)?.type === TranslatableItemType.ELEMENT_SEO
 
-              if (visibleChildAllowed || metadataChildAllowed || forceVisibility) {
+              if (visibleChildAllowed || metadataChildAllowed || forceTranslation) {
                 this.addUserElementToCollection(translatableParentElements, currentParent)
                 this.addUserElementToCollection(translatableElements, element)
               }
@@ -1208,7 +1211,7 @@ class DOMTranslation {
                 currentSourceLangSame,
                 currentIsTranslatable,
                 mode,
-                forceVisibility,
+                forceTranslation,
                 currentParent
               )
             })

--- a/src/js/lib/DOMTranslation.ts
+++ b/src/js/lib/DOMTranslation.ts
@@ -976,7 +976,7 @@ class DOMTranslation {
       }
     }
     for (const range of translationRanges) {
-      range.visibleInCurrentView = this.pluginOptions.translation.translateWholePage ? true : DOMExtensions.elementIsVisible(range.startMarker, this.registredIframes)
+      range.visibleInCurrentView = DOMExtensions.elementIsVisible(range.startMarker, this.registredIframes)
       range.type = TranslatableItemType.ELEMENT
       range.html = this.cropAndMinifyTranslationRange(range, translatableElements, range.startMarker, range.startMarker, range.endMarker)
     }

--- a/src/js/models/PluginOptions.ts
+++ b/src/js/models/PluginOptions.ts
@@ -12,7 +12,7 @@ export const pluginOptions: IPluginOptions = {
   },
   translation: {
     autoTranslate: true,
-    translateWholePage: true,
+    translateWholePage: false,
     // systems: null,
     targetLanguages: null,
     translateOnlyAllowedTags: false,

--- a/src/js/models/PluginOptions.ts
+++ b/src/js/models/PluginOptions.ts
@@ -12,7 +12,7 @@ export const pluginOptions: IPluginOptions = {
   },
   translation: {
     autoTranslate: true,
-    translateWholePage: false,
+    translateWholePage: null,
     // systems: null,
     targetLanguages: null,
     translateOnlyAllowedTags: false,

--- a/src/js/models/PluginOptions.ts
+++ b/src/js/models/PluginOptions.ts
@@ -12,6 +12,7 @@ export const pluginOptions: IPluginOptions = {
   },
   translation: {
     autoTranslate: true,
+    translateWholePage: true,
     // systems: null,
     targetLanguages: null,
     translateOnlyAllowedTags: false,
@@ -39,7 +40,7 @@ export const pluginOptions: IPluginOptions = {
     alwaysShowOriginalTextInPopup: false,
     showPopupTranslationProvider: true,
     showPopup: true,
-    showLanguagesInNativeLanguage: false,
+    showLanguagesInNativeLanguage: true,
     branding: {
       name: 'Tilde',
       url: '',


### PR DESCRIPTION
it is set as default, but can be turned off whenever needed, returning logic of translating only visible elements